### PR TITLE
AbstractDelegateEntry toString() handle not initialized delegate, fixes #7

### DIFF
--- a/src/main/java/org/protege/xmlcatalog/entry/AbstractDelegateEntry.java
+++ b/src/main/java/org/protege/xmlcatalog/entry/AbstractDelegateEntry.java
@@ -51,6 +51,13 @@ public abstract class AbstractDelegateEntry extends Entry implements XmlBaseCont
     }
     
     public String toString() {
-    	return "--> Delegate Catalog(@" + delegate.getXmlBase() + ")";
+        if(delegate == null){
+            try {
+                delegate =getParsedCatalog();
+            } catch (IOException e) {
+                return "Catalog not found";
+            }
+        }
+        return "--> Delegate Catalog(@" + delegate.getXmlBase() + ")";
     }
 }


### PR DESCRIPTION
When editing a catalog from Protégé, the delegate might not be
initialized yet